### PR TITLE
Removed escape in JSON result

### DIFF
--- a/embed/app/views.py
+++ b/embed/app/views.py
@@ -307,11 +307,12 @@ def oEmbed():
 	else:
 		filename = '%s/%s' % (item_id, order)
 	
+	embed_code = '<iframe src="http://media.embedr.eu/%s" width=%s height=%s frameborder=0 allowfullscreen>' % (item_id,int(width),int(height))
 	data = {}
 	data[u'version'] = '1.0'
 	data[u'type'] = 'rich'
 	data[u'title'] = item.title
-	data[u'html'] = html_escape('<iframe src="http://media.embedr.eu/%s" width=%s height=%s frameborder="0" allowfullscreen>' % (item_id,int(width),int(height)))
+	data[u'html'] = html_escape(embed_code)
 	data[u'author_name'] = item.creator
 	data[u'author_url'] = item.source
 	data[u'provider_name'] = item.institution
@@ -320,6 +321,7 @@ def oEmbed():
 	if format == 'xml':
 		return render_template('oembed_xml.html', data = data), 200, {'Content-Type': 'text/xml'}
 	else:
+		data[u'html'] = embed_code
 		return json.dumps(data), 200, {'Content-Type': 'application/json'}
 
 

--- a/embed/test.py
+++ b/embed/test.py
@@ -99,7 +99,7 @@ class EmbedTestCase(unittest.TestCase):
 	def test_oEmbed2(self):
 		rv = self.app.get('/oembed?url=http%3A//127.0.0.1%3A5000/test_id/1&format=json')
 		assert rv.status_code == 200
-		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "&lt;iframe src=&#34;http://media.embedr.eu/test_id&#34; width=100 height=100 frameborder=&#34;0&#34; allowfullscreen&gt;", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}', rv.data, rv.data)
+		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "<iframe src=\\"http://media.embedr.eu/test_id\\" width=100 height=100 frameborder=0 allowfullscreen>", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}', rv.data, rv.data)
 
 	def test_oEmbed3(self):
 		rv = self.app.get('/oembed?url=http%3A//127.0.0.1%3A5000/test_id/1&format=xml')
@@ -109,7 +109,7 @@ class EmbedTestCase(unittest.TestCase):
     <version>1.0</version>
     <type>rich</type>
     <title>Unittest title</title>
-    <html>&lt;iframe src=&#34;http://media.embedr.eu/test_id&#34; width=100 height=100 frameborder=&#34;0&#34; allowfullscreen&gt;</html>
+    <html>&lt;iframe src=&#34;http://media.embedr.eu/test_id&#34; width=100 height=100 frameborder=0 allowfullscreen&gt;</html>
     <author_name>Unittest creator</author_name>
     <author_url>http://unittest_source.org</author_url>
     <provider_name>Unittest institution</provider_name>
@@ -138,22 +138,22 @@ class EmbedTestCase(unittest.TestCase):
 	def test_oEmbed8(self):
 		rv = self.app.get('/oembed?url=http%3A//127.0.0.1%3A5000/test_id/1')
 		assert rv.status_code == 200
-		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "&lt;iframe src=&#34;http://media.embedr.eu/test_id&#34; width=100 height=100 frameborder=&#34;0&#34; allowfullscreen&gt;", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}', rv.data, rv.data)
+		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "<iframe src=\\"http://media.embedr.eu/test_id\\" width=100 height=100 frameborder=0 allowfullscreen>", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}', rv.data, rv.data)
 
 	def test_oEmbed9(self):
 		rv = self.app.get('/oembed?url=http%3A//127.0.0.1%3A5000/test_id/1&maxwidth=50')
 		assert rv.status_code == 200
-		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "&lt;iframe src=&#34;http://media.embedr.eu/test_id&#34; width=50 height=50 frameborder=&#34;0&#34; allowfullscreen&gt;", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}',rv.data,rv.data)
+		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "<iframe src=\\"http://media.embedr.eu/test_id\\" width=50 height=50 frameborder=0 allowfullscreen>", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}',rv.data,rv.data)
 		
 	def test_oEmbed10(self):
 		rv = self.app.get('/oembed?url=http%3A//127.0.0.1%3A5000/test_id/1&maxheight=50')
 		assert rv.status_code == 200
-		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "&lt;iframe src=&#34;http://media.embedr.eu/test_id&#34; width=50 height=50 frameborder=&#34;0&#34; allowfullscreen&gt;", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}',rv.data,rv.data)
+		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "<iframe src=\\"http://media.embedr.eu/test_id\\" width=50 height=50 frameborder=0 allowfullscreen>", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}',rv.data,rv.data)
 
 	def test_oEmbed11(self):
 		rv = self.app.get('/oembed?url=http%3A//127.0.0.1%3A5000/test_id/1&maxheight=25&maxwidth=50')
 		assert rv.status_code == 200
-		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "&lt;iframe src=&#34;http://media.embedr.eu/test_id&#34; width=25 height=25 frameborder=&#34;0&#34; allowfullscreen&gt;", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}',rv.data,rv.data)
+		self.assertEqual('{"provider_url": "http://unittest_institution_link.org", "title": "Unittest title", "html": "<iframe src=\\"http://media.embedr.eu/test_id\\" width=25 height=25 frameborder=0 allowfullscreen>", "author_name": "Unittest creator", "version": "1.0", "author_url": "http://unittest_source.org", "provider_name": "Unittest institution", "type": "rich"}',rv.data,rv.data)
 
 	def test_ingest0(self):
 		rv = self.app.get('/ingest')


### PR DESCRIPTION
I misread the OEmbed standard and escaped both XML and JSON. Only XML needs to be escaped. I've reversed that in this pull request.

I expect a pull request by Tom later today, so please wait in accepting until both of them are present.
